### PR TITLE
Add evcc command extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.dylib
 .DS_Store
 *.pdf
+logo.png
 
 # Test binary, built with `go test -c`
 *.test

--- a/cmd/configuration.go
+++ b/cmd/configuration.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"github.com/HappyTobi/warp/pkg/cmd/configuration"
+	"github.com/spf13/cobra"
+)
+
+func ConfigurationCmd() *cobra.Command {
+	configuration := &cobra.Command{
+		Use:   "configuration",
+		Short: "Create warp cli configuration file",
+		RunE:  configuration.Create,
+	}
+
+	return configuration
+}

--- a/cmd/evcc.go
+++ b/cmd/evcc.go
@@ -43,6 +43,7 @@ func enableCmd() *cobra.Command {
 		RunE:  evcc.Enable,
 	}
 
+	enableCmd.Flags().StringP("user", "r", "", "User to start charging (default is provided username)")
 	enableCmd.Flags().String("enable", "false", "Enable charging")
 
 	return enableCmd

--- a/cmd/evcc.go
+++ b/cmd/evcc.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"github.com/HappyTobi/warp/pkg/cmd/evcc"
+	"github.com/spf13/cobra"
+)
+
+func EvccCmd() *cobra.Command {
+	evcc := &cobra.Command{
+		Use:   "evcc",
+		Short: "Evcc command",
+		Long:  "Evcc command to integration the warp chager with user authentication into evcc",
+	}
+
+	evcc.AddCommand(statusCmd())
+	evcc.AddCommand(enabledCmd())
+	evcc.AddCommand(enableCmd())
+	evcc.AddCommand(maxcurrentCmd())
+
+	return evcc
+}
+
+func statusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Return status of the charger for evcc",
+		RunE:  evcc.Status,
+	}
+}
+
+func enabledCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "enabled",
+		Short: "Return enabled status of the charger for evcc",
+		RunE:  evcc.Enabled,
+	}
+}
+
+func enableCmd() *cobra.Command {
+	enableCmd := &cobra.Command{
+		Use:   "enable",
+		Short: "Enable the charger for evcc",
+		RunE:  evcc.Enable,
+	}
+
+	enableCmd.Flags().String("enable", "false", "Enable charging")
+
+	return enableCmd
+}
+
+func maxcurrentCmd() *cobra.Command {
+	maxcurrentCmd := &cobra.Command{
+		Use:   "maxcurrent",
+		Short: "Set the maxcurrent apaire for the charger from evcc",
+		RunE:  evcc.MaxCurrent,
+	}
+
+	maxcurrentCmd.Flags().Int("current", -1, "Currente ampere")
+
+	return maxcurrentCmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,27 +1,24 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
-	"path/filepath"
-
-	"github.com/HappyTobi/warp/pkg/cmd/settings"
+	"github.com/HappyTobi/warp/pkg/cmd/configuration"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-)
-
-const (
-	oldConfig      = ".warp.yaml"
-	configFileName = "warp.yaml"
 )
 
 func Root() *cobra.Command {
 	root := &cobra.Command{
 		Use: "warp",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			//load the configuration file
+			configPath, _ := cmd.Flags().GetString("config")
+			return configuration.ReadConfig(configPath)
+		},
 	}
 
 	root.PersistentFlags().StringP("charger", "c", "", "Url to Warp charger like http://192.168.1.2 or http://warp.local")
 	root.PersistentFlags().StringP("output", "o", "json", "Output format (json, yaml)")
+
+	root.PersistentFlags().String("config", "", "Path to the warp configuration file (default $HOME/.config/warp/warp.yaml)")
 
 	root.PersistentFlags().StringP("username", "u", "", "Username to authenticate (required if password is set)")
 	root.PersistentFlags().StringP("password", "p", "", "Password to authenticate (required if username is set)")
@@ -34,79 +31,12 @@ func Root() *cobra.Command {
 	root.AddCommand(MeterCmd())
 	root.AddCommand(EvccCmd())
 	root.AddCommand(VersionCmd())
+	root.AddCommand(ConfigurationCmd())
 
 	return root
 }
 
 func init() {
-	cobra.OnInitialize(initConfig)
-}
-
-// TODO move to settings package
-func initConfig() {
-	home, err := os.UserHomeDir()
-	cobra.CheckErr(err)
-
-	configPath := filepath.Join(home, ".config", "warp")
-	configFilePath := filepath.Join(configPath, configFileName)
-	configFilePathLegacy := filepath.Join(home, oldConfig)
-
-	migrated := false
-	if _, err := os.Stat(configFilePathLegacy); !os.IsNotExist(err) {
-		fmt.Println("Configurations file will me moved and updated to new format")
-		_ = os.MkdirAll(configPath, os.ModePerm)
-		if err := os.Rename(configFilePathLegacy, configFilePath); err != nil {
-			fmt.Println("Error while moving config file")
-			os.Exit(1)
-		}
-		os.Remove(configFilePathLegacy)
-		migrated = true
-	}
-
-	viper.AddConfigPath(configPath)
-	viper.SetConfigType("yaml")
-	viper.SetConfigName("warp")
-
-	if err := viper.ReadInConfig(); err == nil && !migrated {
-		return
-	}
-
-	viper.SetDefault("settings.user.firstname", "happy")
-	viper.SetDefault("settings.user.lastname", "tobi")
-	viper.SetDefault("settings.user.street", "githubroad")
-	viper.SetDefault("settings.user.postcode", "0000")
-	viper.SetDefault("settings.user.city", "internet")
-
-	viper.SetDefault("settings.date_time.time_zone", "Europe/Berlin")
-	viper.SetDefault("settings.date_time.time_format", "15:04:05 02-01-2006")
-	viper.SetDefault("settings.power.price", "0.35")
-
-	//csv settings
-	viper.SetDefault("csv.comma", ";")
-	viper.SetDefault("csv.header", true)
-
-	//pdf settings
-	viper.SetDefault("pdf.print_header", false)
-	imagePath := filepath.Join(configPath, "logo.png")
-	viper.SetDefault("pdf.image_path", imagePath)
-
-	if _, err := os.Stat(configFilePath); os.IsNotExist(err) {
-		_ = os.MkdirAll(configPath, os.ModePerm)
-		if err := os.WriteFile(configFilePath, []byte{}, os.ModePerm); err != nil {
-			fmt.Print("Error while creating config file")
-			os.Exit(1)
-		}
-	}
-
-	if err := settings.StoreImage(imagePath); err != nil {
-		fmt.Print("Error while storing image")
-		os.Exit(1)
-	}
-
-	if err := viper.WriteConfig(); err != nil {
-		fmt.Print(err)
-		os.Exit(1)
-	}
-
-	fmt.Println("New warp config file created at:", viper.ConfigFileUsed())
+	// enable all pre functions
+	cobra.EnableTraverseRunHooks = true
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,6 +32,7 @@ func Root() *cobra.Command {
 	root.AddCommand(UserCmd())
 	root.AddCommand(ChargeTrackerCmd())
 	root.AddCommand(MeterCmd())
+	root.AddCommand(EvccCmd())
 	root.AddCommand(VersionCmd())
 
 	return root

--- a/pkg/cmd/configuration/create.go
+++ b/pkg/cmd/configuration/create.go
@@ -1,0 +1,73 @@
+package configuration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/HappyTobi/warp/pkg/cmd/settings"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func Create(cmd *cobra.Command, args []string) error {
+	fmt.Println("New warp config file created at:", viper.ConfigFileUsed())
+
+	return nil
+}
+
+func CreateConfigFile(configPath string) error {
+	viper.AddConfigPath(filepath.Dir(configPath))
+
+	viper.SetConfigType(strings.ReplaceAll(filepath.Ext(configPath), ".", ""))
+	viper.SetConfigFile(filepath.Base(configPath))
+
+	if err := viper.ReadInConfig(); err == nil {
+		// file already exist
+		return nil
+	}
+
+	viper.SetDefault("settings.user.firstname", "happy")
+	viper.SetDefault("settings.user.lastname", "tobi")
+	viper.SetDefault("settings.user.street", "githubroad")
+	viper.SetDefault("settings.user.postcode", "0000")
+	viper.SetDefault("settings.user.city", "internet")
+
+	viper.SetDefault("settings.date_time.time_zone", "Europe/Berlin")
+	viper.SetDefault("settings.date_time.time_format", "15:04:05 02-01-2006")
+	viper.SetDefault("settings.power.price", "0.35")
+
+	//csv settings
+	viper.SetDefault("csv.comma", ";")
+	viper.SetDefault("csv.header", true)
+
+	//pdf settings
+	viper.SetDefault("pdf.print_header", false)
+	dirName := filepath.Dir(configPath)
+	imagePath := filepath.Join(dirName, "logo.png")
+	viper.SetDefault("pdf.image_path", imagePath)
+
+	//charger settings
+	viper.SetDefault("charger.url", "")
+	viper.SetDefault("charger.username", "")
+	viper.SetDefault("charger.password", "")
+
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		if _, derr := os.Stat(dirName); derr != nil {
+			_ = os.MkdirAll(configPath, os.ModePerm)
+		}
+	}
+
+	if err := settings.StoreImage(imagePath); err != nil {
+		fmt.Print("Error while storing image")
+		return err
+	}
+
+	if err := viper.WriteConfig(); err != nil {
+		fmt.Print(err)
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cmd/configuration/read.go
+++ b/pkg/cmd/configuration/read.go
@@ -1,0 +1,29 @@
+package configuration
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+func ReadConfig(configPathArg string) error {
+
+	configPath := configPathArg
+	if len(configPathArg) == 0 {
+		home, err := os.UserHomeDir()
+		cobra.CheckErr(err)
+
+		configPath = filepath.Join(home, ".config", "warp", "warp.yaml")
+	}
+
+	// TODO add validation that file base and extension exists
+
+	absConfigFilePath, _ := filepath.Abs(configPath)
+
+	if err := CreateConfigFile(absConfigFilePath); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/cmd/evcc/evcc.go
+++ b/pkg/cmd/evcc/evcc.go
@@ -1,0 +1,104 @@
+package evcc
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/HappyTobi/warp/pkg/cmd/middleware"
+	"github.com/HappyTobi/warp/pkg/internal/evse"
+	"github.com/spf13/cobra"
+)
+
+// https://docs.warp-charger.com/docs/mqtt_http/api_reference/evse#evse_state_warp1
+func Status(cmd *cobra.Command, args []string) error {
+	request, err := middleware.LoadWarpRequest(cmd)
+	if err != nil {
+		return err
+	}
+
+	evseService := evse.NewEvseService(request)
+	state, err := evseService.State()
+	if err != nil {
+		return err
+	}
+
+	//we have to return state A...F from field: iec61851_state
+	iecState := state["iec61851_state"]
+	if v, ok := iecState.(float64); ok {
+		switch v {
+		case 0:
+			fmt.Print("A")
+		case 1:
+			fmt.Print("B")
+		case 2:
+			fmt.Print("C")
+		case 3:
+			fmt.Print("D")
+		case 4:
+			fmt.Print("F")
+		}
+
+		return nil
+	}
+
+	return fmt.Errorf("error while checking charger state")
+}
+
+func Enabled(cmd *cobra.Command, args []string) error {
+	request, err := middleware.LoadWarpRequest(cmd)
+	if err != nil {
+		return err
+	}
+
+	evseService := evse.NewEvseService(request)
+	current, err := evseService.ReadExternalCurrent()
+	if err != nil {
+		return err
+	}
+
+	enabled := "false"
+
+	if current >= 6000 {
+		enabled = "true"
+	}
+
+	fmt.Print(enabled)
+
+	return nil
+}
+
+func Enable(cmd *cobra.Command, args []string) error {
+	enable, err := cmd.Flags().GetString("enable")
+	if err != nil {
+		return err
+	}
+
+	request, err := middleware.LoadWarpRequest(cmd)
+	if err != nil {
+		return err
+	}
+
+	evseService := evse.NewEvseService(request)
+
+	current := 0
+	if strings.EqualFold(enable, "true") {
+		current = 6000
+	}
+
+	return evseService.SetExternalCurrent(current)
+}
+
+func MaxCurrent(cmd *cobra.Command, args []string) error {
+	currentAmpere, err := cmd.Flags().GetInt("current")
+	if err != nil {
+		return err
+	}
+
+	request, err := middleware.LoadWarpRequest(cmd)
+	if err != nil {
+		return err
+	}
+
+	evseService := evse.NewEvseService(request)
+	return evseService.SetExternalCurrent(currentAmpere)
+}

--- a/pkg/cmd/middleware/flags.go
+++ b/pkg/cmd/middleware/flags.go
@@ -6,6 +6,7 @@ import (
 	"github.com/HappyTobi/warp/pkg/internal/renderer"
 	"github.com/HappyTobi/warp/pkg/internal/warp"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func LoadWarpRequest(cmd *cobra.Command) (warp.Request, error) {
@@ -34,7 +35,20 @@ func LoadGlobalParams(cmd *cobra.Command, req func(charger, username, password, 
 	output, _ := cmd.Root().Flags().GetString("output")
 
 	if len(charger) == 0 {
-		return fmt.Errorf("could not find warp charger address")
+		//load from config
+		charger = viper.GetString("charger.url")
+		if len(charger) == 0 {
+			return fmt.Errorf("could not find warp charger address as argument or part of the configuration file %s", viper.ConfigFileUsed())
+		}
+	}
+
+	// load user and pass from config when empty, empty values are fine
+	if len(user) == 0 {
+		user = viper.GetString("charger.username")
+	}
+
+	if len(pass) == 0 {
+		pass = viper.GetString("charger.password")
 	}
 
 	req(charger, user, pass, output)

--- a/pkg/internal/evse/entity.go
+++ b/pkg/internal/evse/entity.go
@@ -11,3 +11,7 @@ type Evse struct {
 type ChargePower struct {
 	Current int `json:"current"`
 }
+
+type ExternelCurrent struct {
+	Current int `json:"current"`
+}

--- a/pkg/internal/evse/externalCurrent.go
+++ b/pkg/internal/evse/externalCurrent.go
@@ -1,0 +1,36 @@
+package evse
+
+import "encoding/json"
+
+func (e *Evse) ReadExternalCurrent() (int, error) {
+	e.request.Path = "evse/external_current"
+
+	data, err := e.request.Get()
+	if err != nil {
+		return -1, err
+	}
+
+	var externalCurrent ExternelCurrent
+	if err := json.Unmarshal(data, &externalCurrent); err != nil {
+		return -1, err
+	}
+
+	return externalCurrent.Current, nil
+}
+
+func (e *Evse) SetExternalCurrent(val int) error {
+	e.request.Path = "evse/external_current"
+
+	externelCurrent := ExternelCurrent{Current: val}
+
+	payload, err := json.Marshal(&externelCurrent)
+	if err != nil {
+		return err
+	}
+
+	if _, err := e.request.Post(payload); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/warp-example.yaml
+++ b/warp-example.yaml
@@ -1,0 +1,22 @@
+charger:
+    password: ""
+    url: ""
+    username: ""
+csv:
+    comma: ;
+    header: true
+pdf:
+    image_path: /workspaces/warp/logo.png
+    print_header: false
+settings:
+    date_time:
+        time_format: 15:04:05 02-01-2006
+        time_zone: Europe/Berlin
+    power:
+        price: "0.35"
+    user:
+        city: internet
+        firstname: happy
+        lastname: tobi
+        postcode: "0000"
+        street: githubroad


### PR DESCRIPTION
Add new functionality to use the warp cli at evcc to interact with the warp charger and the user authentication.

Features:
Evcc commands
Configuration file can now be passed as argument "--config <PATH>warp.yaml"
