### PR TITLE
Fix: configure clear on disconnect

### DIFF
--- a/cmd/evcc.go
+++ b/cmd/evcc.go
@@ -30,9 +30,10 @@ func statusCmd() *cobra.Command {
 
 func enabledCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "enabled",
-		Short: "Return enabled status of the charger for evcc",
-		RunE:  evcc.Enabled,
+		Use:     "enabled",
+		Short:   "Return enabled status of the charger for evcc",
+		PreRunE: evcc.PreEnabled,
+		RunE:    evcc.Enabled,
 	}
 }
 

--- a/pkg/cmd/evcc/evcc.go
+++ b/pkg/cmd/evcc/evcc.go
@@ -56,7 +56,12 @@ func PreEnabled(cmd *cobra.Command, args []string) error {
 	evseService := evse.NewEvseService(request)
 
 	// valid setting for clear on disconnect, we have to enable it when it's false to check.
-	if ok, _ := evseService.GetExternalClearOnDisconnect(); !ok {
+	ok, err := evseService.GetExternalClearOnDisconnect()
+	if err != nil {
+		return err
+	}
+
+	if !ok {
 		// enable the settings
 		if err := evseService.EnableClearOnDisconnect(); err != nil {
 			return err

--- a/pkg/cmd/evcc/evcc.go
+++ b/pkg/cmd/evcc/evcc.go
@@ -46,6 +46,26 @@ func Status(cmd *cobra.Command, args []string) error {
 	return fmt.Errorf("error while checking charger state")
 }
 
+// pre validate the setting of clear on disconnect
+func PreEnabled(cmd *cobra.Command, args []string) error {
+	request, err := middleware.LoadWarpRequest(cmd)
+	if err != nil {
+		return err
+	}
+
+	evseService := evse.NewEvseService(request)
+
+	// valid setting for clear on disconnect, we have to enable it when it's false to check.
+	if ok, _ := evseService.GetExternalClearOnDisconnect(); !ok {
+		// enable the settings
+		if err := evseService.EnableClearOnDisconnect(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func Enabled(cmd *cobra.Command, args []string) error {
 	request, err := middleware.LoadWarpRequest(cmd)
 	if err != nil {

--- a/pkg/internal/evse/entity.go
+++ b/pkg/internal/evse/entity.go
@@ -15,3 +15,7 @@ type ChargePower struct {
 type ExternelCurrent struct {
 	Current int `json:"current"`
 }
+
+type ClearOnDisconnect struct {
+	Enabled bool `json:"clear_on_disconnect"`
+}

--- a/pkg/internal/evse/externalCurrent.go
+++ b/pkg/internal/evse/externalCurrent.go
@@ -18,6 +18,39 @@ func (e *Evse) ReadExternalCurrent() (int, error) {
 	return externalCurrent.Current, nil
 }
 
+func (e *Evse) GetExternalClearOnDisconnect() (bool, error) {
+	e.request.Path = "evse/external_clear_on_disconnect"
+
+	data, err := e.request.Get()
+	if err != nil {
+		return false, err
+	}
+
+	var clearOnDisconnect ClearOnDisconnect
+	if err := json.Unmarshal(data, &clearOnDisconnect); err != nil {
+		return false, err
+	}
+
+	return clearOnDisconnect.Enabled, nil
+}
+
+func (e *Evse) EnableClearOnDisconnect() error {
+	e.request.Path = "evse/external_clear_on_disconnect"
+
+	clearOnDisconnect := ClearOnDisconnect{Enabled: true}
+
+	payload, err := json.Marshal(&clearOnDisconnect)
+	if err != nil {
+		return err
+	}
+
+	if _, err := e.request.Post(payload); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (e *Evse) SetExternalCurrent(val int) error {
 	e.request.Path = "evse/external_current"
 


### PR DESCRIPTION
Add pre function at the evcc "enabled" call to set the clear on disconnect option to "true".
The pre function is fixing the state of the current charge value when the cable is disconnected. (Value will be set to 0)